### PR TITLE
chore: update version to 2.4.11 and modify installer URL and checksum

### DIFF
--- a/.nuspec
+++ b/.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>witsy</id>
-    <version>2.4.10</version>
+    <version>2.4.11</version>
     <title>Witsy is a BYOK (Bring Your Own Keys) AI application</title>
     <authors>Nicolas Bonamy</authors>
     <owners>Mohammad Abu Mattar</owners>
@@ -91,7 +91,7 @@ You can transcribe audio recorded on the microphone to text. Transcription can b
 https://www.youtube.com/watch?v=vixl7I07hBk
     ]]></description>
     <summary>Witsy: A flexible BYOK AI application for integrating various LLM providers or running models locally.</summary>
-    <releaseNotes>https://github.com/nbonamy/witsy/releases/tag/v2.4.10</releaseNotes>
+    <releaseNotes>https://github.com/nbonamy/witsy/releases/tag/v2.4.11</releaseNotes>
     <tags>witsy ai byok llm ollama</tags>
     <packageSourceUrl>https://github.com/MKAbuMattar/witsy-chocolatey-package</packageSourceUrl>
     <docsUrl>https://github.com/nbonamy/witsy/blob/main/README.md</docsUrl>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop';
 $packageName = 'Witsy'
-$url = 'https://github.com/nbonamy/witsy/releases/download/v2.4.10/Witsy-2.4.10-win32-x64.Setup.exe'
+$url = 'https://github.com/nbonamy/witsy/releases/download/v2.4.11/Witsy-2.4.11-win32-x64.Setup.exe'
 $installerType = 'exe'
-$checksum = '61333C957741F231448B4FC1F7CE7B711BD6CC9C671D38D4BDB7C80E2215543F'
+$checksum = '4FF28FF20AA4310C7D6C8B0D4954C9D09415D51AA905EA654E5BF0DF9376EA0C'
 $checksumType = 'sha256'
 $silentArgs = '/S'
 $validExitCodes = @(0)


### PR DESCRIPTION
This pull request updates the Witsy package to version 2.4.11, including adjustments to metadata, release notes, and installation script to reflect the new version.

### Version Update:

* [`.nuspec`](diffhunk://#diff-a8a3258dc219b359d928c74ed68cb3e730ae40b324d7ada24c9f99bd2ea694c9L5-R5): Updated the package version from `2.4.10` to `2.4.11` and changed the release notes URL accordingly. [[1]](diffhunk://#diff-a8a3258dc219b359d928c74ed68cb3e730ae40b324d7ada24c9f99bd2ea694c9L5-R5) [[2]](diffhunk://#diff-a8a3258dc219b359d928c74ed68cb3e730ae40b324d7ada24c9f99bd2ea694c9L94-R94)

* [`tools/chocolateyInstall.ps1`](diffhunk://#diff-c8f6abc2ccedfe23bdef7041bb85de5f8e2ed640a05c59d7fad3411951f36a54L3-R5): Updated the download URL and checksum to match the new version `2.4.11`.