### PR TITLE
fix: update silent installation arguments for Witsy installer

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $url = 'https://github.com/nbonamy/witsy/releases/download/v2.5.1/Witsy-2.5.1-wi
 $installerType = 'exe'
 $checksum = '235FFBB0924F365CE2F87B6DC06538A79D488C9BA45B251D5F6AA436D9849286'
 $checksumType = 'sha256'
-$silentArgs = '/S'
+$silentArgs = '/S /quiet'
 $validExitCodes = @(0)
 
 $installPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"


### PR DESCRIPTION
This pull request includes a minor update to the `tools/chocolateyInstall.ps1` script. The change modifies the `silentArgs` parameter to include an additional `/quiet` flag, ensuring a quieter installation process.