### PR TITLE
Update Witsy Chocolatey Package to v2.8.0

### DIFF
--- a/.nuspec
+++ b/.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>witsy</id>
-    <version>2.7.2</version>
+    <version>2.8.0</version>
     <title>Witsy is a BYOK (Bring Your Own Keys) AI application</title>
     <authors>Nicolas Bonamy</authors>
     <owners>Mohammad Abu Mattar</owners>
@@ -91,7 +91,7 @@ You can transcribe audio recorded on the microphone to text. Transcription can b
 https://www.youtube.com/watch?v=vixl7I07hBk
     ]]></description>
     <summary>Witsy: A flexible BYOK AI application for integrating various LLM providers or running models locally.</summary>
-    <releaseNotes>https://github.com/nbonamy/witsy/releases/tag/v2.7.2</releaseNotes>
+    <releaseNotes>https://github.com/nbonamy/witsy/releases/tag/v2.8.0</releaseNotes>
     <tags>witsy ai byok llm ollama</tags>
     <packageSourceUrl>https://github.com/MKAbuMattar/witsy-chocolatey-package</packageSourceUrl>
     <docsUrl>https://github.com/nbonamy/witsy/blob/main/README.md</docsUrl>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop';
 $packageName = 'Witsy'
-$url = 'https://github.com/nbonamy/witsy/releases/download/v2.7.2/Witsy-2.7.2-win32-x64.Setup.exe'
+$url = 'https://github.com/nbonamy/witsy/releases/download/v2.8.0/Witsy-2.8.0-win32-x64.Setup.exe'
 $installerType = 'exe'
-$checksum = '557FEDD5704E43E6DC85AA7289234BC4ACD9C7128769C3D719E6B840413F1CC4'
+$checksum = 'F05FFC416EAD9E16DC21D7093A3615B967D1850652B5B7909F64300CB8F0C18F'
 $checksumType = 'sha256'
 $silentArgs = '/S /quiet'
 $validExitCodes = @(0)


### PR DESCRIPTION
This PR updates the Witsy Chocolatey package to version v2.8.0, including the installer URL and checksum.